### PR TITLE
修复在mac下获取libreoffice的soffice文件错误的问题；本修改不影响openoffice的使用。

### DIFF
--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/OfficeUtils.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/OfficeUtils.java
@@ -116,7 +116,7 @@ public class OfficeUtils {
 
     public static File getOfficeExecutable(File officeHome) {
         if (PlatformUtils.isMac()) {
-            return new File(officeHome, "MacOS/soffice.bin");
+            return new File(officeHome, "MacOS/soffice");
         } else {
             return new File(officeHome, "program/soffice.bin");
         }


### PR DESCRIPTION
在mac下：
LibreOffice的soffice没有.bin扩展名；
OpenOffice的soffice有两个，一个soffice，一个是soffice.bin;
默认的代码，在mac下是无法使用的。
经测试，将OfficeUtils类的getOfficeExecutable方法中关于mac取值：
return new File(officeHome, "MacOS/soffice.bin");
修改为：
return new File(officeHome, "MacOS/soffice");
修改后对于LibreOffice和OpenOffice均可在Mac下使用。
测试环境：
Mac OS 10.13.6;
openoffice 4.1.6;
libreOffice 6.2.4.2;
