### PR TITLE
支持 SimText 原样格式输出

### DIFF
--- a/jodconverter-web/src/main/resources/web/txt.ftl
+++ b/jodconverter-web/src/main/resources/web/txt.ftl
@@ -45,7 +45,7 @@
             type: 'GET',
             url: '${ordinaryUrl}',
             success: function (data) {
-                $("#text").html(data);
+                $("#text").html("<pre>" + data + "</pre>");
             }
         });
     }


### PR DESCRIPTION
原有simText预览时，原有的换行等格式不被识别，添加<pre>强制按原有格式显示