### PR TITLE
文本乱码问题

### DIFF
--- a/jodconverter-web/src/main/java/cn/keking/utils/FileCharsetDetector.java
+++ b/jodconverter-web/src/main/java/cn/keking/utils/FileCharsetDetector.java
@@ -76,18 +76,17 @@ public class FileCharsetDetector {
     byte[] buf = new byte[1024];
     int len;
     boolean done = false;
-    boolean isAscii = false;
+    boolean isAscii = true;
 
     while ((len = imp.read(buf, 0, buf.length)) != -1) {
       // Check if the stream is only ascii.
-      isAscii = det.isAscii(buf, len);
-      if (isAscii) {
-        break;
+      if (isAscii){
+        isAscii = det.isAscii(buf,len);
       }
+
       // DoIt if non-ascii and not done yet.
-      done = det.DoIt(buf, len, false);
-      if (done) {
-        break;
+      if (!isAscii && !done){
+        done = det.DoIt(buf,len, false);
       }
     }
     imp.close();

--- a/jodconverter-web/src/main/resources/web/txt.ftl
+++ b/jodconverter-web/src/main/resources/web/txt.ftl
@@ -45,7 +45,7 @@
             type: 'GET',
             url: '${ordinaryUrl}',
             success: function (data) {
-                $("#text").html(data);
+                $("#text").html("<pre>" + data + "</pre>");
             }
         });
     }


### PR DESCRIPTION
原方式会出现乱码。原方式导致误判：第一个buf如果全是ascii，就认为全部是ascii，实际上后面可能有其他编码。需要判断流中所有byte。
