### PR TITLE
修复：dwg文件预览时无法在jpg和pdf两种类型之间切换

### DIFF
--- a/server/src/main/java/cn/keking/service/impl/CadFilePreviewImpl.java
+++ b/server/src/main/java/cn/keking/service/impl/CadFilePreviewImpl.java
@@ -35,7 +35,7 @@ public class CadFilePreviewImpl implements FilePreview {
     @Override
     public String filePreviewHandle(String url, Model model, FileAttribute fileAttribute) {
         // 预览Type，参数传了就取参数的，没传取系统默认
-        String officePreviewType = model.asMap().get("officePreviewType") == null ? ConfigConstants.getOfficePreviewType() : model.asMap().get("officePreviewType").toString();
+        String officePreviewType = fileAttribute.getOfficePreviewType() == null ? ConfigConstants.getOfficePreviewType() : fileAttribute.getOfficePreviewType();
         String baseUrl = BaseUrlFilter.getBaseUrl();
         String fileName = fileAttribute.getName();
         String pdfName = fileName.substring(0, fileName.lastIndexOf(".") + 1) + "pdf";


### PR DESCRIPTION
修复：dwg文件预览时无法在jpg和pdf两种类型之间切换