### PR TITLE
修复重复编码导致文档转图片预览失败的问题&编码规范

### DIFF
--- a/server/src/main/java/cn/keking/service/FileHandlerService.java
+++ b/server/src/main/java/cn/keking/service/FileHandlerService.java
@@ -178,14 +178,15 @@ public class FileHandlerService {
         String pdfFolder = pdfName.substring(0, pdfName.length() - 4);
         String urlPrefix;
         try {
-            urlPrefix = baseUrl + URLEncoder.encode(URLEncoder.encode(pdfFolder, uriEncoding).replaceAll("\\+", "%20"), uriEncoding);
+            urlPrefix = baseUrl + URLEncoder.encode(pdfFolder, uriEncoding).replaceAll("\\+", "%20");
         } catch (UnsupportedEncodingException e) {
             logger.error("UnsupportedEncodingException", e);
             urlPrefix = baseUrl + pdfFolder;
         }
         if (imageCount != null && imageCount > 0) {
-            for (int i = 0; i < imageCount; i++)
+            for (int i = 0; i < imageCount; i++) {
                 imageUrls.add(urlPrefix + "/" + i + imageFileSuffix);
+            }
             return imageUrls;
         }
         try {


### PR DESCRIPTION
URLEncoder.encode(URLEncoder.encode(pdfFolder, uriEncoding).replaceAll("\+", "%20"), uriEncoding);
这里encode了两次，导致图片预览失败。