### PR TITLE
添加通过 http header X-Base-Url 来动态传入 baseUrl 的功能

### DIFF
--- a/server/src/main/java/cn/keking/web/filter/BaseUrlFilter.java
+++ b/server/src/main/java/cn/keking/web/filter/BaseUrlFilter.java
@@ -18,7 +18,7 @@ public class BaseUrlFilter implements Filter {
     public static String getBaseUrl() {
         String baseUrl;
         try {
-            baseUrl = (String) RequestContextHolder.currentRequestAttributes().getAttribute("baseUrl",0);
+            baseUrl = (String) RequestContextHolder.currentRequestAttributes().getAttribute("baseUrl", 0);
         } catch (Exception e) {
             baseUrl = BASE_URL;
         }
@@ -34,9 +34,6 @@ public class BaseUrlFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
         String baseUrl;
-        StringBuilder pathBuilder = new StringBuilder();
-        pathBuilder.append(request.getScheme()).append("://").append(request.getServerName()).append(":")
-                .append(request.getServerPort()).append(((HttpServletRequest) request).getContextPath()).append("/");
         String baseUrlTmp = ConfigConstants.getBaseUrl();
         if (baseUrlTmp != null && !ConfigConstants.DEFAULT_BASE_URL.equalsIgnoreCase(baseUrlTmp)) {
             if (!baseUrlTmp.endsWith("/")) {
@@ -44,7 +41,8 @@ public class BaseUrlFilter implements Filter {
             }
             baseUrl = baseUrlTmp;
         } else {
-            baseUrl = pathBuilder.toString();
+            baseUrl = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort()
+                    + ((HttpServletRequest) request).getContextPath() + "/";
         }
         BASE_URL = baseUrl;
         request.setAttribute("baseUrl", baseUrl);

--- a/server/src/main/java/cn/keking/web/filter/BaseUrlFilter.java
+++ b/server/src/main/java/cn/keking/web/filter/BaseUrlFilter.java
@@ -1,6 +1,7 @@
 package cn.keking.web.filter;
 
 import cn.keking.config.ConfigConstants;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 
 import javax.servlet.*;
@@ -33,16 +34,25 @@ public class BaseUrlFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
         String baseUrl;
         String baseUrlTmp = ConfigConstants.getBaseUrl();
-        if (baseUrlTmp != null && !ConfigConstants.DEFAULT_BASE_URL.equalsIgnoreCase(baseUrlTmp)) {
+
+        final HttpServletRequest servletRequest = (HttpServletRequest) request;
+        // 支持通过 http header 中 X-Base-Url 来动态设置 baseUrl 以支持多个域名/项目的共享使用
+        final String urlInHeader = servletRequest.getHeader("X-Base-Url");
+        if (StringUtils.isNotEmpty(urlInHeader)) {
+            baseUrl = urlInHeader;
+        } else if (baseUrlTmp != null && !ConfigConstants.DEFAULT_BASE_URL.equalsIgnoreCase(baseUrlTmp)) {
+            // 如果配置文件中配置了 baseUrl 且不为 default 则以配置文件为准
             if (!baseUrlTmp.endsWith("/")) {
                 baseUrlTmp = baseUrlTmp.concat("/");
             }
             baseUrl = baseUrlTmp;
         } else {
+            // 动态拼接 baseUrl
             baseUrl = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort()
-                    + ((HttpServletRequest) request).getContextPath() + "/";
+                    + servletRequest.getContextPath() + "/";
         }
         BASE_URL = baseUrl;
         request.setAttribute("baseUrl", baseUrl);


### PR DESCRIPTION
考虑到开发环境下为多个项目都单独开一个实例的话资源占用就有点大了，尝试共享一个实例的方式。

受限于程序默认的 `context-path`为固定值，我们在使用`nginx`反代的时候能做的文章就是 `host( ip + port)`，但是路径那块没有办法调整，只能是每个项目都是固定值才可以。比如设置成 `/kkview` 那么 `a.com,b.com,c.com` 都必须给 `nginx` 配置上 `location=kkview` 的值，其它的会导致生成预览时相关文件的路径不正确。
```nginx
location /kkview {
  proxy_pass real-view-host;
  proxy_set_header Host $host;
}
````

倒是不如支持一下 `http header`来动态传入，现在我们可以这样做：
1. 给 kkFileView　设定一个 context-path （默认/也可以)
2. 每个项目都可以自定义一个自己的 `path`，比如:
 ```nginx
# 对于 a.com
location /foo/ {
  proxy_pass http://127.0.0.1:7799;
  proxy_set_header X-Base-Url http://a.com/foo/;
}
# 如果是 b.com
location /bar/ {
  proxy_pass http://127.0.0.1:7799;
  proxy_set_header X-Base-Url http://b.com/bar/;
}
```