### PR TITLE
修复: 文件名含有特殊字符时无法预览

### DIFF
--- a/server/src/main/java/cn/keking/service/FileHandlerService.java
+++ b/server/src/main/java/cn/keking/service/FileHandlerService.java
@@ -273,6 +273,7 @@ public class FileHandlerService {
         attribute.setType(type);
         attribute.setName(fileName);
         attribute.setSuffix(suffix);
+        url = WebUtils.encodeUrlFileName(url);
         attribute.setUrl(url);
         if (req != null) {
             String officePreviewType = req.getParameter("officePreviewType");

--- a/server/src/main/java/cn/keking/utils/WebUtils.java
+++ b/server/src/main/java/cn/keking/utils/WebUtils.java
@@ -2,8 +2,10 @@ package cn.keking.utils;
 
 import io.mola.galimatias.GalimatiasParseException;
 
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -96,5 +98,24 @@ public class WebUtils {
         String nonPramStr = url.substring(0, url.contains("?") ? url.indexOf("?") : url.length());
         String fileName = nonPramStr.substring(nonPramStr.lastIndexOf("/") + 1);
         return KkFileUtils.suffixFromFileName(fileName);
+    }
+
+    /**
+     * 对url中的文件名进行UTF-8编码
+     *
+     * @param url url
+     * @return 文件名编码后的url
+     */
+    public static String encodeUrlFileName(String url) {
+        String noQueryUrl = url.substring(0, url.contains("?") ? url.indexOf("?") : url.length());
+        int fileNameStartIndex = noQueryUrl.lastIndexOf('/') + 1;
+        int fileNameEndIndex = noQueryUrl.lastIndexOf('.');
+        String encodedFileName;
+        try {
+            encodedFileName = URLEncoder.encode(noQueryUrl.substring(fileNameStartIndex, fileNameEndIndex), "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            return null;
+        }
+        return url.substring(0, fileNameStartIndex) + encodedFileName + url.substring(fileNameEndIndex);
     }
 }

--- a/server/src/test/java/cn/keking/utils/WebUtilsTests.java
+++ b/server/src/test/java/cn/keking/utils/WebUtilsTests.java
@@ -1,0 +1,24 @@
+package cn.keking.utils;
+
+import org.junit.jupiter.api.Test;
+
+public class WebUtilsTests {
+
+    @Test
+    void encodeUrlFileNameTest() {
+        // 测试对URL中的文件名部分进行UTF-8编码
+        String in = "https://file.keking.cn/demo/hello#0.txt";
+        String out = "https://file.keking.cn/demo/hello%230.txt";
+        assert WebUtils.encodeUrlFileName(in).equals(out);
+    }
+
+    @Test
+    void encodeUrlFileNameTestWithParams() {
+        // 测试对URL中的文件名部分进行UTF-8编码
+        // URL带参数
+        // 文件名"#hello&world"中的"&"应该被编码成为"%26"，而?后的参数列表中的"&"不会被编码
+        String in = "https://file.keking.cn/demo/#hello&world.txt?param0=0&param1=1";
+        String out = "https://file.keking.cn/demo/%23hello%26world.txt?param0=0&param1=1";
+        assert WebUtils.encodeUrlFileName(in).equals(out);
+    }
+}


### PR DESCRIPTION
[#271 文件名含有特殊字符时无法预览](https://github.com/kekingcn/kkFileView/issues/271)