### PR TITLE
让 office-plugin 项目的 Java 语言级别与父项目保持一致

### DIFF
--- a/office-plugin/pom.xml
+++ b/office-plugin/pom.xml
@@ -88,16 +88,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.7.2</version>
                 <configuration>


### PR DESCRIPTION
目前父项目的语言级别是 java 8，而 office-plugin 的语言级别还停留在 java 6，所以建议升级到 java 8，以便利用新的 java 语法。