### PR TITLE
修复单元测试失败的问题

### DIFF
--- a/office-plugin/pom.xml
+++ b/office-plugin/pom.xml
@@ -88,16 +88,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.7.2</version>
                 <configuration>

--- a/office-plugin/pom.xml
+++ b/office-plugin/pom.xml
@@ -88,6 +88,16 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.7.2</version>
                 <configuration>

--- a/office-plugin/src/main/java/org/artofsolving/jodconverter/util/ConfigUtils.java
+++ b/office-plugin/src/main/java/org/artofsolving/jodconverter/util/ConfigUtils.java
@@ -49,7 +49,7 @@ public class ConfigUtils {
 
     public static String getOfficePluginPath() {
         String userDir = System.getProperty("user.dir");
-        String binFolder = env("KKFILEVIEW_BIN_FOLDER", userDir);
+        String binFolder = envOrDefault("KKFILEVIEW_BIN_FOLDER", userDir);
 
         File pluginPath = new File(binFolder);
 

--- a/office-plugin/src/main/java/org/artofsolving/jodconverter/util/ConfigUtils.java
+++ b/office-plugin/src/main/java/org/artofsolving/jodconverter/util/ConfigUtils.java
@@ -9,6 +9,7 @@ import java.io.File;
 public class ConfigUtils {
 
     private static final String MAIN_DIRECTORY_NAME = "server";
+
     private static final String OFFICE_PLUGIN_NAME = "office-plugin";
 
     public static String getHomePath() {
@@ -21,7 +22,7 @@ public class ConfigUtils {
         } else {
             String separator = File.separator;
             if (userDir.contains(MAIN_DIRECTORY_NAME)) {
-                userDir = userDir + separator + "src" + separator +  "main";
+                userDir = userDir + separator + "src" + separator + "main";
             } else {
                 userDir = userDir + separator + MAIN_DIRECTORY_NAME + separator + "src" + separator + "main";
             }
@@ -29,21 +30,43 @@ public class ConfigUtils {
         return userDir;
     }
 
+    // 获取环境变量，如果找不到则返回默认值
+    @SuppressWarnings("SameParameterValue")
+    private static String env(String key, String def) {
+        String value = System.getenv(key);
+        return value == null ? def : value;
+    }
 
-    public static String getOfficePluginPath() {
-        String userDir = System.getenv("KKFILEVIEW_BIN_FOLDER");
-        if (userDir == null) {
-            userDir = System.getProperty("user.dir");
-        }
-        if (userDir.endsWith("bin")) {
-            userDir = userDir.substring(0, userDir.length() - 4);
-        } else {
-            String separator = File.separator;
-            if (!userDir.contains(OFFICE_PLUGIN_NAME)) {
-                userDir = userDir + separator + OFFICE_PLUGIN_NAME;
+    // 返回参数列表中第一个真实存在的路径，或者 null
+    private static String firstExists(File... paths) {
+        for (File path : paths) {
+            if (path.exists()) {
+                return path.getAbsolutePath();
             }
         }
-        return userDir;
+        return null;
+    }
+
+    public static String getOfficePluginPath() {
+        String userDir = System.getProperty("user.dir");
+        String binFolder = env("KKFILEVIEW_BIN_FOLDER", userDir);
+
+        File pluginPath = new File(binFolder);
+
+        // 如果指定了 bin 或其父目录，则返回父目录
+        // 否则在当前目录和父目录中寻找 office-plugin
+        if (new File(pluginPath, "bin").exists()) {
+            return pluginPath.getAbsolutePath();
+
+        } else if (pluginPath.exists() && pluginPath.getName().equals("bin")) {
+            return pluginPath.getParentFile().getAbsolutePath();
+
+        } else {
+            return firstExists(
+                    new File(pluginPath, OFFICE_PLUGIN_NAME),
+                    new File(pluginPath.getParentFile(), OFFICE_PLUGIN_NAME)
+            );
+        }
     }
 
     public static String getCustomizedConfigPath() {

--- a/office-plugin/src/main/java/org/artofsolving/jodconverter/util/ConfigUtils.java
+++ b/office-plugin/src/main/java/org/artofsolving/jodconverter/util/ConfigUtils.java
@@ -32,7 +32,7 @@ public class ConfigUtils {
 
     // 获取环境变量，如果找不到则返回默认值
     @SuppressWarnings("SameParameterValue")
-    private static String env(String key, String def) {
+    private static String envOrDefault(String key, String def) {
         String value = System.getenv(key);
         return value == null ? def : value;
     }


### PR DESCRIPTION
在 IntelliJ 中，运行 ServerMain 和 ServerMainTests 是在两个不同目录下的，因此获取到的环境变量 user.dir 的值会不同：

![MIbu7OB6UL](https://user-images.githubusercontent.com/900606/130432809-6a154fd0-0aeb-444c-a1de-2baf3c140eb0.png)

这会导致单元测试运行时找不到 office-plugin 的位置。本 PR 重写了 `ConfigUtils.getOfficePluginPath()` 方法，修复了这个问题。