### PR TITLE
修复BUG：当上传到本地的文件名中包含空格时，无法预览

### DIFF
--- a/server/src/main/java/cn/keking/utils/DownloadUtils.java
+++ b/server/src/main/java/cn/keking/utils/DownloadUtils.java
@@ -32,7 +32,7 @@ public class DownloadUtils {
      * @return 本地文件绝对路径
      */
     public static ReturnResponse<String> downLoad(FileAttribute fileAttribute, String fileName) {
-        String urlStr = fileAttribute.getUrl();
+        String urlStr = fileAttribute.getUrl().replace("+", "%20");
         ReturnResponse<String> response = new ReturnResponse<>(0, "下载成功!!!", "");
         String realPath = DownloadUtils.getRelFilePath(fileName, fileAttribute);
         try {


### PR DESCRIPTION
用于修复 issue #293 