### PR TITLE
feat(增加token校验): 增加token校验

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -249,6 +249,13 @@
             <classifier>windows-x86_64</classifier>
         </dependency>
 
+        <!-- okhttpClient -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.14.9</version>
+        </dependency>
+
 
     </dependencies>
 

--- a/server/src/main/config/application.properties
+++ b/server/src/main/config/application.properties
@@ -99,4 +99,6 @@ watermark.width = ${WATERMARK_WIDTH:180}
 watermark.height = ${WATERMARK_HEIGHT:80}
 #水印倾斜度数，要求设置在大于等于0，小于90
 watermark.angle = ${WATERMARK_ANGLE:10}
+#配置下载文件时的token在header中的名字,默认Authorization
+request.auth.name=Authorization
 

--- a/server/src/main/java/cn/keking/model/FileAttribute.java
+++ b/server/src/main/java/cn/keking/model/FileAttribute.java
@@ -13,6 +13,7 @@ public class FileAttribute {
     private String name;
     private String url;
     private String fileKey;
+    private String token;
     private String officePreviewType = ConfigConstants.getOfficePreviewType();
 
     public FileAttribute() {
@@ -79,5 +80,13 @@ public class FileAttribute {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
     }
 }

--- a/server/src/main/java/cn/keking/service/FileHandlerService.java
+++ b/server/src/main/java/cn/keking/service/FileHandlerService.java
@@ -45,6 +45,11 @@ public class FileHandlerService {
     @Value("${server.tomcat.uri-encoding:UTF-8}")
     private String uriEncoding;
 
+    @Value("${request.auth.name:Authorization}")
+    private String tokenName;
+
+
+
     public FileHandlerService(CacheService cacheService) {
         this.cacheService = cacheService;
     }
@@ -261,6 +266,8 @@ public class FileHandlerService {
         FileType type;
         String fileName;
         String fullFileName = WebUtils.getUrlParameterReg(url, "fullfilename");
+        String token = WebUtils.getUrlParameterReg(url, tokenName);
+        attribute.setToken(token);
         if (StringUtils.hasText(fullFileName)) {
             fileName = fullFileName;
             type = FileType.typeFromFileName(fullFileName);
@@ -269,11 +276,11 @@ public class FileHandlerService {
             fileName = WebUtils.getFileNameFromURL(url);
             type = FileType.typeFromUrl(url);
             suffix = WebUtils.suffixFromUrl(url);
+            url = WebUtils.encodeUrlFileName(url);
         }
         attribute.setType(type);
         attribute.setName(fileName);
         attribute.setSuffix(suffix);
-        url = WebUtils.encodeUrlFileName(url);
         attribute.setUrl(url);
         if (req != null) {
             String officePreviewType = req.getParameter("officePreviewType");

--- a/server/src/main/java/cn/keking/service/impl/MediaFilePreviewImpl.java
+++ b/server/src/main/java/cn/keking/service/impl/MediaFilePreviewImpl.java
@@ -8,6 +8,7 @@ import cn.keking.service.FilePreview;
 import cn.keking.utils.DownloadUtils;
 import cn.keking.service.FileHandlerService;
 import cn.keking.web.filter.BaseUrlFilter;
+import org.apache.commons.lang3.StringUtils;
 import org.artofsolving.jodconverter.util.ConfigUtils;
 import org.bytedeco.ffmpeg.global.avcodec;
 import org.bytedeco.javacv.FFmpegFrameGrabber;
@@ -39,7 +40,7 @@ public class MediaFilePreviewImpl implements FilePreview {
     @Override
     public String filePreviewHandle(String url, Model model, FileAttribute fileAttribute) {
         // 不是http开头，浏览器不能直接访问，需下载到本地
-        if (url != null && !url.toLowerCase().startsWith("http")) {
+        if ((url != null && !url.toLowerCase().startsWith("http")) || StringUtils.isNotEmpty(fileAttribute.getToken())) {
             ReturnResponse<String> response = DownloadUtils.downLoad(fileAttribute, fileAttribute.getName());
             if (response.isFailure()) {
                 return otherFilePreview.notSupportedFile(model, fileAttribute, response.getMsg());

--- a/server/src/main/java/cn/keking/service/impl/PictureFilePreviewImpl.java
+++ b/server/src/main/java/cn/keking/service/impl/PictureFilePreviewImpl.java
@@ -5,6 +5,7 @@ import cn.keking.model.ReturnResponse;
 import cn.keking.service.FilePreview;
 import cn.keking.utils.DownloadUtils;
 import cn.keking.service.FileHandlerService;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.ui.Model;
 import org.springframework.util.CollectionUtils;
@@ -36,7 +37,7 @@ public class PictureFilePreviewImpl implements FilePreview {
             imgUrls.addAll(zipImgUrls);
         }
         // 不是http开头，浏览器不能直接访问，需下载到本地
-        if (url != null && !url.toLowerCase().startsWith("http")) {
+        if ((url != null && !url.toLowerCase().startsWith("http")) || StringUtils.isNotEmpty(fileAttribute.getToken())) {
             ReturnResponse<String> response = DownloadUtils.downLoad(fileAttribute, null);
             if (response.isFailure()) {
                 return otherFilePreview.notSupportedFile(model, fileAttribute, response.getMsg());

--- a/server/src/main/java/cn/keking/utils/OkHttpClientUtils.java
+++ b/server/src/main/java/cn/keking/utils/OkHttpClientUtils.java
@@ -1,0 +1,49 @@
+package cn.keking.utils;
+
+import okhttp3.Headers;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @Author: Zy
+ * @Date: 2021/10/9 15:48
+ * okhttpclient工具类
+ */
+public class OkHttpClientUtils {
+    private static OkHttpClient client = null;
+
+    public static OkHttpClient instance() {
+        if(client==null){
+            client = new OkHttpClient.Builder()
+                    .connectTimeout(30, TimeUnit.SECONDS)
+                    .readTimeout(30, TimeUnit.SECONDS)
+                    .callTimeout(30, TimeUnit.SECONDS)
+                    .writeTimeout(30, TimeUnit.SECONDS)
+                    .build();
+        }
+        return client;
+    }
+
+    /**
+     * 发送get请求,传入headers
+     * @author Zy
+     * @date 2021/10/9
+     * @param url
+     * @param headers
+     * @return okhttp3.Response
+     */
+    public static Response executeGet(URL url, Headers headers) throws IOException {
+        Request request = new Request.Builder()
+                .get()
+                .url(url)
+                .headers(headers)
+                .build();
+        return instance().newCall(request).execute();
+    }
+
+}


### PR DESCRIPTION
1.使用http/https下载链接预览文件时,如果url中带有?会导致下载报错  #292 
2.当下载路径需要传递请求头做权限校验时,增加权限校验,在下载路径后拼接&token=xxx即可,默认请求头为Authorization,也可以修改配置文件修改