### PR TITLE
修复文件流获取文件名错误的问题

### DIFF
--- a/server/src/main/config/application.properties
+++ b/server/src/main/config/application.properties
@@ -117,3 +117,5 @@ watermark.angle = ${WATERMARK_ANGLE:10}
 #Tif类型图片浏览模式：tif（利用前端js插件浏览）；jpg（转换为jpg后前端显示）；pdf（转换为pdf后显示，便于打印）
 tif.preview.type = ${KK_TIF_PREVIEW_TYPE:tif}
 
+#文件下载流URL中获取文件名的正则表达式
+file.stream-url.file-name.regex = ${KK_FILE_STREAM_URL_FILENAME_REGEX:[^\\/\\\\&\\?]+\\.\\w{1,4}(?=([\\?&].*$|$))}

--- a/server/src/main/java/cn/keking/config/ConfigConstants.java
+++ b/server/src/main/java/cn/keking/config/ConfigConstants.java
@@ -42,6 +42,7 @@ public class ConfigConstants {
     private static String pdfBookmarkDisable;
     private static Boolean fileUploadDisable;
     private static String tifPreviewType;
+    private static String streamUrlFileNameRegex;
 
     public static final String DEFAULT_CACHE_ENABLED = "true";
     public static final String DEFAULT_TXT_TYPE = "txt,html,htm,asp,jsp,xml,json,properties,md,gitignore,log,java,py,c,cpp,sql,sh,bat,m,bas,prg,cmd";
@@ -353,4 +354,18 @@ public class ConfigConstants {
     public static void setTifPreviewTypeValue(String tifPreviewType) {
         ConfigConstants.tifPreviewType = tifPreviewType;
     }
+
+    public static String getStreamUrlFileNameRegex() {
+        return streamUrlFileNameRegex;
+    }
+
+    @Value("${file.stream-url.file-name.regex:[^\\/\\\\&\\?]+\\.\\w{1,4}(?=([\\?&].*$|$))}")
+    public void setStreamUrlFileNameRegex(String streamUrlFileNameRegex) {
+        setStreamUrlFileNameRegexValue(streamUrlFileNameRegex);
+    }
+
+    public static void setStreamUrlFileNameRegexValue(String streamUrlFileNameRegex) {
+        ConfigConstants.streamUrlFileNameRegex = streamUrlFileNameRegex;
+    }
+
 }

--- a/server/src/main/java/cn/keking/model/FileType.java
+++ b/server/src/main/java/cn/keking/model/FileType.java
@@ -1,6 +1,7 @@
 package cn.keking.model;
 
 import cn.keking.config.ConfigConstants;
+import cn.keking.utils.WebUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -87,6 +88,17 @@ public enum FileType {
      * @return 文件类型
      */
     public static FileType typeFromUrl(String url) {
+        String fileName = WebUtils.getFileNameFromURL(url);
+        return typeFromFileName(fileName);
+    }
+
+    /**
+     * 查看文件类型(防止参数中存在.点号或者其他特殊字符，所以先抽取文件名，然后再获取文件类型)
+     *
+     * @param url url
+     * @return 文件类型
+     */
+    public static FileType typeFromUrlOld(String url) {
         String nonPramStr = url.substring(0, url.contains("?") ? url.indexOf("?") : url.length());
         String fileName = nonPramStr.substring(nonPramStr.lastIndexOf("/") + 1);
         return typeFromFileName(fileName);


### PR DESCRIPTION
当前对于从文件流获取文件名无法兼容文件名不在末尾（http://ip/file.doc）而在查询参数中（http://ip/document?fileName=file.doc）的形式。