### PR TITLE
log4j2漏洞升级、修正currentUrl为下载后文件地址进行预览

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ nbdist/
 
 server/src/main/cache/
 server/src/main/file/
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <java.version>1.8</java.version>
         <spring.boot.version>2.4.2</spring.boot.version>
+        <log4j2.version>2.17.2</log4j2.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -19,11 +19,41 @@
                 <version>${spring.boot.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-to-slf4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
+        <!-- log4j -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>${log4j2.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-freemarker</artifactId>

--- a/server/src/main/java/cn/keking/service/impl/PictureFilePreviewImpl.java
+++ b/server/src/main/java/cn/keking/service/impl/PictureFilePreviewImpl.java
@@ -1,5 +1,6 @@
 package cn.keking.service.impl;
 
+import cn.keking.config.ConfigConstants;
 import cn.keking.model.FileAttribute;
 import cn.keking.model.ReturnResponse;
 import cn.keking.service.FilePreview;
@@ -28,6 +29,7 @@ public class PictureFilePreviewImpl implements FilePreview {
 
     @Override
     public String filePreviewHandle(String url, Model model, FileAttribute fileAttribute) {
+    	String base_url=ConfigConstants.getBaseUrl();
         List<String> imgUrls = new ArrayList<>();
         imgUrls.add(url);
         String fileKey = fileAttribute.getFileKey();
@@ -35,14 +37,16 @@ public class PictureFilePreviewImpl implements FilePreview {
         if (!CollectionUtils.isEmpty(zipImgUrls)) {
             imgUrls.addAll(zipImgUrls);
         }
-        // 不是http开头，浏览器不能直接访问，需下载到本地
-        if (url != null && !url.toLowerCase().startsWith("http")) {
+        // ftp 或 http 文件先下载到本地
+        if (url != null && (url.toLowerCase().startsWith("http")||url.toLowerCase().startsWith("ftp"))) {
             ReturnResponse<String> response = DownloadUtils.downLoad(fileAttribute, null);
             if (response.isFailure()) {
                 return otherFilePreview.notSupportedFile(model, fileAttribute, response.getMsg());
             } else {
                 String file = fileHandlerService.getRelativePath(response.getContent());
                 imgUrls.clear();
+                //xuenhua 修正currentUrl为下载后文件地址进行预览
+                file=base_url+ "/"+file;
                 imgUrls.add(file);
                 model.addAttribute("imgUrls", imgUrls);
                 model.addAttribute("currentUrl", file);


### PR DESCRIPTION
1. log4j2漏洞升级
2. 修正currentUrl为下载后文件地址进行预览