### PR TITLE
取消url编码，以临时解决不能预览ftp服务器上中文名称文件的问题。

### DIFF
--- a/server/src/main/java/cn/keking/service/FileHandlerService.java
+++ b/server/src/main/java/cn/keking/service/FileHandlerService.java
@@ -276,7 +276,7 @@ public class FileHandlerService {
         attribute.setType(type);
         attribute.setName(fileName);
         attribute.setSuffix(suffix);
-        url = WebUtils.encodeUrlFileName(url);
+        //url = WebUtils.encodeUrlFileName(url);
         attribute.setUrl(url);
         if (req != null) {
             String officePreviewType = req.getParameter("officePreviewType");


### PR DESCRIPTION
下载ftp服务器上的文件时，会对url进行utf-8编码，而windows server 2016自带的ftp服务器是不识别这种编码后的url的（其他环境未测试）。
有使用中文名称文件需求的在FileHandlerService.java里注释掉 url = WebUtils.encodeUrlFileName(url);这行可以临时解决。