### PR TITLE
fix(sec): upgrade com.thoughtworks.xstream:xstream to 1.4.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <spring.boot.version>2.4.2</spring.boot.version>
         <poi.version>5.2.2</poi.version>
         <xdocreport.version>1.0.6</xdocreport.version>
-        <xstream.version>1.4.19</xstream.version>
+        <xstream.version>1.4.20</xstream.version>
         <junrar.version>7.4.1</junrar.version>
         <redisson.version>3.2.0</redisson.version>
         <sevenzipjbinding.version>16.02-2.01</sevenzipjbinding.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerability found in com.thoughtworks.xstream:xstream 1.4.19
- [CVE-2022-41966](https://www.oscs1024.com/hd/CVE-2022-41966)


### What did I do？
Upgrade com.thoughtworks.xstream:xstream from 1.4.19 to 1.4.20 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS