### PR TITLE
fix: remove global index from lazyload to avoid being polluted

### DIFF
--- a/server/src/main/resources/static/js/lazyload.js
+++ b/server/src/main/resources/static/js/lazyload.js
@@ -6,9 +6,8 @@ function isInSight(el) {
     return bound.top <= clientHeight + 100;
 }
 
-var index = 0;
-
 function checkImgs() {
+    var index = 0;
     var imgs = document.querySelectorAll('.my-photo');
     for (var i = index; i < imgs.length; i++) {
         if (isInSight(imgs[i])) {


### PR DESCRIPTION
The variable "index" is being set to -1 by some of my chrome extension. To avoid this, I just move it into the "checkImgs" function.