### PR TITLE
perf: 优化FilePreviewFactory#get方法获取service bean的方式

### DIFF
--- a/server/src/main/java/cn/keking/service/FilePreviewFactory.java
+++ b/server/src/main/java/cn/keking/service/FilePreviewFactory.java
@@ -4,8 +4,6 @@ import cn.keking.model.FileAttribute;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
-
 /**
  * Created by kl on 2018/1/17.
  * Content :
@@ -20,7 +18,6 @@ public class FilePreviewFactory {
     }
 
     public FilePreview get(FileAttribute fileAttribute) {
-        Map<String, FilePreview> filePreviewMap = context.getBeansOfType(FilePreview.class);
-        return filePreviewMap.get(fileAttribute.getType().getInstanceName());
+        return context.getBean(fileAttribute.getType().getInstanceName(), FilePreview.class);
     }
 }


### PR DESCRIPTION
perf: 修改了FilePreviewFactory#get方法获取service bean的方式，由原来的先获取所有FilePreview类型的bean再根据bean name获取bean改为直接根据bean name获取单个bean