### PR TITLE
fix: 处理fileName为不合法的命名

### DIFF
--- a/server/src/main/java/cn/keking/service/FileHandlerService.java
+++ b/server/src/main/java/cn/keking/service/FileHandlerService.java
@@ -429,6 +429,8 @@ public class FileHandlerService {
             attribute.setSkipDownLoad(true);
         }
         url = WebUtils.encodeUrlFileName(url);
+         // 把不合法的名称转换
+        fileName = KkFileUtils.convertToValidFileName(fileName);
         fileName = KkFileUtils.htmlEscape(fileName);  //文件名处理
         attribute.setType(type);
         attribute.setName(fileName);

--- a/server/src/main/java/cn/keking/utils/DownloadUtils.java
+++ b/server/src/main/java/cn/keking/utils/DownloadUtils.java
@@ -49,6 +49,13 @@ public class DownloadUtils {
         }
         ReturnResponse<String> response = new ReturnResponse<>(0, "下载成功!!!", "");
         String realPath = getRelFilePath(fileName, fileAttribute);
+        // 首先处理realPath是否为合法的相对地址
+         if(!StringUtils.hasText(realPath)){
+            response.setCode(1);
+            response.setContent(null);
+            response.setMsg("下载失败:文件名不合法!" + urlStr);
+            return response;
+        }
         if (!KkFileUtils.isAllowedUpload(realPath)) {
             response.setCode(1);
             response.setContent(null);
@@ -59,12 +66,6 @@ public class DownloadUtils {
         if (urlStr.contains("?fileKey=")) {
             response.setContent(fileDir + fileName);
             response.setMsg(fileName);
-            return response;
-        }
-        if(!StringUtils.hasText(realPath)){
-            response.setCode(1);
-            response.setContent(null);
-            response.setMsg("下载失败:文件名不合法!" + urlStr);
             return response;
         }
         if(realPath.equals("cunzhai")){


### PR DESCRIPTION
 发现出现文件 ..pdf的时候文件名不合法 代码处理位置不对
fix: 调整处理realPath是否为合法的相对地址代码的位置

后面考虑了下，可以避免这个bug 就又提交了点， 还加上来测试，基本考虑到之前的几种不合法的文件命名