### PR TITLE
fix: duplicate query param of tifPreviewType on url

### DIFF
--- a/server/src/main/resources/web/pdf.ftl
+++ b/server/src/main/resources/web/pdf.ftl
@@ -37,7 +37,14 @@
     }
 
     function goForImage() {
-        var url = window.location.href + "&tifPreviewType=jpg"
+        var url = window.location.href
+        
+        if (url.indexOf("tifPreviewType=pdf") != -1) {
+            url = url.replace("tifPreviewType=pdf", "tifPreviewType=jpg");
+        } else {
+            url = url + "&tifPreviewType=jpg";
+        }
+
         if (url.indexOf("officePreviewType=pdf") != -1) {
             url = url.replace("officePreviewType=pdf", "officePreviewType=image");
         } else {


### PR DESCRIPTION
close #497 