### PR TITLE
Fix预览本地带有加号的文件夹比如AI+行业时，转码不对导致的报错

### DIFF
--- a/server/src/main/java/cn/keking/utils/DownloadUtils.java
+++ b/server/src/main/java/cn/keking/utils/DownloadUtils.java
@@ -54,7 +54,7 @@ public class DownloadUtils {
         String urlStr = null;
         try {
             SslUtils.ignoreSsl();
-            urlStr = fileAttribute.getUrl().replaceAll("\\+", "%20").replaceAll(" ", "%20");
+            urlStr = fileAttribute.getUrl().replaceAll("\\+", "%2B").replaceAll(" ", "%20");
         } catch (Exception e) {
             logger.error("忽略SSL证书异常:", e);
         }


### PR DESCRIPTION
预览服务器上通过nginx直接代理出去的文件路径时，如果文件夹含有+号的话，会转码成空格的编码，当初可能是为了兼容处理含有空格文件夹的编码吧？ 但是文件夹真正含有 + 号时候，这样替换后就无法找到文件去预览了。