### PR TITLE
fix(excle):1、当ipad上横屏预览时,需要指定height为100%,不然只能显示、滚动半屏页面

### DIFF
--- a/server/src/main/resources/web/html.ftl
+++ b/server/src/main/resources/web/html.ftl
@@ -9,7 +9,7 @@
     <#include "*/needFilePasswordHeader.ftl">
 </head>
 <body>
-<iframe src="${pdfUrl}" width="100%" frameborder="0"></iframe>
+<iframe src="${pdfUrl}" width="100%" height="100%" frameborder="0"></iframe>
 </body>
 
 <script type="text/javascript">


### PR DESCRIPTION
只有移动端容易复现这个问题,PC端正常