### PR TITLE
修正XSS注入漏洞:处理noTrustHost时目标host为html字符串问题,对html字符串进行转义

### DIFF
--- a/server/src/main/java/cn/keking/web/filter/TrustHostFilter.java
+++ b/server/src/main/java/cn/keking/web/filter/TrustHostFilter.java
@@ -12,6 +12,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
+import fr.opensagres.xdocreport.core.utils.StringEscapeUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.util.FileCopyUtils;
@@ -42,7 +43,7 @@ public class TrustHostFilter implements Filter {
         String host = WebUtils.getHost(url);
         assert host != null;
         if (isNotTrustHost(host)) {
-            String html = this.notTrustHostHtmlView.replace("${current_host}", host);
+            String html = this.notTrustHostHtmlView.replace("${current_host}", StringEscapeUtils.escapeHtml(host));
             response.getWriter().write(html);
             response.getWriter().close();
         } else {


### PR DESCRIPTION
复现步骤:
1. application.properties 中trust.host 指定一个host,如10.0.0.1 2.使用如下文件地址访问:
picturesPreview?url=aHR0cDovLzxpbWcgc3JjPTEgb25lcnJvcj1hbGVydCgxKT4vMS5qcGc= 【该base64解码为<img src=1 onerror=alert(1)>】
3.复现情况:预览该文件浏览器将会弹出alert(1);