### PR TITLE
fix(xlsx): 修复 LuckyExcel 解析数据校验时 matchType 未映射导致的崩溃

### DIFF
--- a/server/src/main/resources/static/xlsx/luckyexcel.umd.js
+++ b/server/src/main/resources/static/xlsx/luckyexcel.umd.js
@@ -4433,7 +4433,7 @@ var LuckySheet = /** @class */function (_super) {
       var _hint = method_1.getXmlAttibute(attrList, "prompt", null);
       var _hintShow = _hint ? true : false;
       var matchType = constant_1.COMMON_TYPE2.includes(_type) ? "common" : _type;
-      _type2 = operator ? constant_1.DATA_VERIFICATION_TYPE2_MAP[matchType][operator] : "bw";
+      _type2 = operator ? (constant_1.DATA_VERIFICATION_TYPE2_MAP[matchType]?.[operator] ?? "bw") : "bw";
       // mobile phone number processing
       if (_type === "text_content" && ((_value1 === null || _value1 === void 0 ? void 0 : _value1.includes("LEN")) || (_value1 === null || _value1 === void 0 ? void 0 : _value1.includes("len"))) && (_value1 === null || _value1 === void 0 ? void 0 : _value1.includes("=11"))) {
         _type = "validity";

--- a/server/src/main/resources/static/xlsx/luckyexcel.umd.js
+++ b/server/src/main/resources/static/xlsx/luckyexcel.umd.js
@@ -4433,7 +4433,8 @@ var LuckySheet = /** @class */function (_super) {
       var _hint = method_1.getXmlAttibute(attrList, "prompt", null);
       var _hintShow = _hint ? true : false;
       var matchType = constant_1.COMMON_TYPE2.includes(_type) ? "common" : _type;
-      _type2 = operator ? (constant_1.DATA_VERIFICATION_TYPE2_MAP[matchType]?.[operator] ?? "bw") : "bw";
+      var _type2Map = constant_1.DATA_VERIFICATION_TYPE2_MAP[matchType];
+      _type2 = operator ? ((_type2Map && _type2Map[operator] != null) ? _type2Map[operator] : "bw") : "bw";
       // mobile phone number processing
       if (_type === "text_content" && ((_value1 === null || _value1 === void 0 ? void 0 : _value1.includes("LEN")) || (_value1 === null || _value1 === void 0 ? void 0 : _value1.includes("len"))) && (_value1 === null || _value1 === void 0 ? void 0 : _value1.includes("=11"))) {
         _type = "validity";
@@ -7421,4 +7422,3 @@ module.exports = main_1.LuckyExcel;
 
 },{"./main":19}]},{},[20])(20)
 });
-

--- a/server/src/main/resources/static/xlsx/luckyexcel.umd.js
+++ b/server/src/main/resources/static/xlsx/luckyexcel.umd.js
@@ -4434,7 +4434,7 @@ var LuckySheet = /** @class */function (_super) {
       var _hintShow = _hint ? true : false;
       var matchType = constant_1.COMMON_TYPE2.includes(_type) ? "common" : _type;
       var _type2Map = constant_1.DATA_VERIFICATION_TYPE2_MAP[matchType];
-      _type2 = operator ? ((_type2Map && _type2Map[operator] != null) ? _type2Map[operator] : "bw") : "bw";
+      _type2 = operator ? (_type2Map ? _type2Map[operator] : "bw") : "bw";
       // mobile phone number processing
       if (_type === "text_content" && ((_value1 === null || _value1 === void 0 ? void 0 : _value1.includes("LEN")) || (_value1 === null || _value1 === void 0 ? void 0 : _value1.includes("len"))) && (_value1 === null || _value1 === void 0 ? void 0 : _value1.includes("=11"))) {
         _type = "validity";


### PR DESCRIPTION
### 问题

在 Excel（xlsx）在线预览使用 `luckyexcel.umd.js` 解析时，部分工作表包含 **数据有效性（dataValidation）**，且类型经 `DATA_VERIFICATION_MAP` 映射后得到的 `matchType`（如 `dropdown`、`checkbox` 等）**不在** `DATA_VERIFICATION_TYPE2_MAP` 中。原实现直接执行：

`DATA_VERIFICATION_TYPE2_MAP[matchType][operator]`

当 `DATA_VERIFICATION_TYPE2_MAP[matchType]` 为 `undefined` 时，再访问 `[operator]`（例如 `between`）会抛出：

```
TypeError: Cannot read properties of undefined (reading 'between')
```

现象：
<img width="3517" height="1440" alt="e539316e23531003f13c956aa98d1a27" src="https://github.com/user-attachments/assets/615dea41-795d-403e-b942-a8f91a4c30fc" />


堆栈：`LuckySheet.generateConfigDataValidations` → `new LuckySheet` → `LuckyFile.Parse`。

### 修复

在 `generateConfigDataValidations` 中先取 `var _t2map = DATA_VERIFICATION_TYPE2_MAP[matchType]`，仅在 `_t2map` 存在且包含对应 `operator` 时使用映射值；否则与原先「无合法映射」时的行为一致，回退为 `"bw"`（与原分支在 `operator` 为空时使用 `"bw"` 的语义对齐）。

### 变更范围

- `server/src/main/resources/static/xlsx/luckyexcel.umd.js`

测试文件：
[luckyexcel-datavalidation-bug.xlsx](https://github.com/user-attachments/files/26619143/luckyexcel-datavalidation-bug.xlsx)
