### PR TITLE
Configurable default PDF sidebar visibility

### DIFF
--- a/server/src/main/config/application.properties
+++ b/server/src/main/config/application.properties
@@ -155,6 +155,9 @@ pdf.bookmark.disable = ${KK_PDF_BOOKMARK_DISABLE:true}
 # 是否禁止PDF编辑功能（注释、表单等），默认为false（允许编辑）
 pdf.disable.editing = ${KK_PDF_DISABLE_EDITING:false}
 
+# 是否默认打开PDF侧边栏（thumbs/outlines/attachments），默认为true（打开）
+pdf.sidebar.open = ${KK_PDF_SIDEBAR_OPEN:true}
+
 # PDF处理最大线程数，控制并发处理能力
 pdf.max.threads = 10
 

--- a/server/src/main/java/cn/keking/config/ConfigConstants.java
+++ b/server/src/main/java/cn/keking/config/ConfigConstants.java
@@ -77,6 +77,7 @@ public class ConfigConstants {
     public static final String DEFAULT_PDF_DOWNLOAD_DISABLE = "true";
     public static final String DEFAULT_PDF_BOOKMARK_DISABLE = "true";
     public static final String DEFAULT_PDF_DISABLE_EDITING = "true";
+    public static final String DEFAULT_PDF_SIDEBAR_OPEN = "true";
     public static final String DEFAULT_PDF2_JPG_DPI = "105";
     public static final String DEFAULT_PDF_SMALL_DTI = "150";
     public static final String DEFAULT_PDF_MEDIUM_DPI = "120";
@@ -194,6 +195,7 @@ public class ConfigConstants {
     private static String pdfPrintDisable;
     private static String pdfDownloadDisable;
     private static String pdfBookmarkDisable;
+    private static String pdfSidebarOpen;
     private static int pdf2JpgDpi;
     private static boolean pdfDpiEnabled;
     private static int pdfSmallDpi;
@@ -336,6 +338,7 @@ public class ConfigConstants {
     public static String getPdfDownloadDisable() { return pdfDownloadDisable; }
     public static String getPdfBookmarkDisable() { return pdfBookmarkDisable; }
     public static String getPdfDisableEditing() { return pdfDisableEditing; }
+    public static String getPdfSidebarOpen() { return pdfSidebarOpen; }
     public static int getPdf2JpgDpi() { return pdf2JpgDpi; }
     public static int getPdfTimeoutSmall() { return pdfTimeoutSmall; }
     public static int getPdfTimeoutMedium() { return pdfTimeoutMedium; }
@@ -562,6 +565,10 @@ public class ConfigConstants {
     @Value("${pdf.disable.editing:true}")
     public void setpdfDisableEditing(String pdfDisableEditing) { setPdfDisableEditingValue(pdfDisableEditing); }
     public static void setPdfDisableEditingValue(String pdfDisableEditing) { ConfigConstants.pdfDisableEditing = pdfDisableEditing; }
+
+    @Value("${pdf.sidebar.open:true}")
+    public void setPdfSidebarOpen(String pdfSidebarOpen) { setPdfSidebarOpenValue(pdfSidebarOpen); }
+    public static void setPdfSidebarOpenValue(String pdfSidebarOpen) { ConfigConstants.pdfSidebarOpen = pdfSidebarOpen; }
 
     @Value("${pdf2jpg.dpi:105}")
     public void pdf2JpgDpi(int pdf2JpgDpi) { setPdf2JpgDpiValue(pdf2JpgDpi); }

--- a/server/src/main/java/cn/keking/config/ConfigRefreshComponent.java
+++ b/server/src/main/java/cn/keking/config/ConfigRefreshComponent.java
@@ -181,6 +181,7 @@ public class ConfigRefreshComponent {
         ConfigConstants.setPdfDownloadDisableValue(getProperty(properties, "pdf.download.disable", ConfigConstants.DEFAULT_PDF_DOWNLOAD_DISABLE));
         ConfigConstants.setPdfBookmarkDisableValue(getProperty(properties, "pdf.bookmark.disable", ConfigConstants.DEFAULT_PDF_BOOKMARK_DISABLE));
         ConfigConstants.setPdfDisableEditingValue(getProperty(properties, "pdf.disable.editing", ConfigConstants.DEFAULT_PDF_DISABLE_EDITING));
+        ConfigConstants.setPdfSidebarOpenValue(getProperty(properties, "pdf.sidebar.open", ConfigConstants.DEFAULT_PDF_SIDEBAR_OPEN));
         ConfigConstants.setPdf2JpgDpiValue(Integer.parseInt(getProperty(properties, "pdf2jpg.dpi", ConfigConstants.DEFAULT_PDF2_JPG_DPI)));
 
         // 8. CAD配置

--- a/server/src/main/java/cn/keking/web/filter/AttributeSetFilter.java
+++ b/server/src/main/java/cn/keking/web/filter/AttributeSetFilter.java
@@ -38,6 +38,7 @@ public class AttributeSetFilter implements Filter {
         request.setAttribute("pdfDownloadDisable", ConfigConstants.getPdfDownloadDisable());
         request.setAttribute("pdfBookmarkDisable", ConfigConstants.getPdfBookmarkDisable());
         request.setAttribute("pdfDisableEditing", ConfigConstants.getPdfDisableEditing());
+        request.setAttribute("pdfSidebarOpen", ConfigConstants.getPdfSidebarOpen());
         request.setAttribute("switchDisabled", ConfigConstants.getOfficePreviewSwitchDisabled());
         request.setAttribute("fileUploadDisable", ConfigConstants.getFileUploadDisable());
         request.setAttribute("beian", ConfigConstants.getBeian());

--- a/server/src/main/resources/web/pdf.ftl
+++ b/server/src/main/resources/web/pdf.ftl
@@ -64,7 +64,11 @@
     viewerUrl += "&watermarktxt=" + watermarkEncoded;
     viewerUrl += "&pdfhighlightall=" + highlightEncoded;
     viewerUrl += "#page=${page}";   // ?c 确保数字不包含千位分隔符
-	viewerUrl += "&pagemode=thumbs";     
+<#if "true" == pdfSidebarOpen>
+	viewerUrl += "&pagemode=thumbs";
+<#else>
+	viewerUrl += "&pagemode=none";
+</#if>
     var iframe = document.getElementById('pdfFrame');
     iframe.src = viewerUrl;
 


### PR DESCRIPTION
## Summary
- Add configurable `pdf.sidebar.open` to control whether PDF preview defaults to opening sidebar (thumbs/outline/attachments).
- Wire this config through `ConfigConstants` and `ConfigRefreshComponent` for runtime refresh support.
- Expose the value to template via `AttributeSetFilter`.
- Update `pdf.ftl` to use `pagemode=thumbs` when enabled, otherwise `pagemode=none`.

## Notes
- Default remains `true` (open by default).
- Can be overridden by env var `KK_PDF_SIDEBAR_OPEN` (e.g. `false`).

## Validation
- `mvn -q -pl server -DskipTests compile`
