### PR TITLE
test: update PDF sidebar compatibility test for configurable mode

### DIFF
--- a/server/src/main/config/application.properties
+++ b/server/src/main/config/application.properties
@@ -155,7 +155,7 @@ pdf.bookmark.disable = ${KK_PDF_BOOKMARK_DISABLE:true}
 # 是否禁止PDF编辑功能（注释、表单等），默认为false（允许编辑）
 pdf.disable.editing = ${KK_PDF_DISABLE_EDITING:false}
 
-# 是否默认打开PDF侧边栏（thumbs/outlines/attachments），默认为true（打开）
+# 是否默认打开PDF侧边栏（缩略图面板），默认为true（打开）
 pdf.sidebar.open = ${KK_PDF_SIDEBAR_OPEN:true}
 
 # PDF处理最大线程数，控制并发处理能力

--- a/server/src/test/java/cn/keking/PdfViewerCompatibilityTests.java
+++ b/server/src/test/java/cn/keking/PdfViewerCompatibilityTests.java
@@ -27,10 +27,12 @@ public class PdfViewerCompatibilityTests {
     }
 
     @Test
-    void shouldOpenPdfPreviewWithThumbnailSidebarByDefault() throws IOException {
+    void shouldRenderPdfSidebarModeByDefaultBasedOnConfig() throws IOException {
         String pdfTemplate = readResource("/web/pdf.ftl");
 
-        assertTrue(pdfTemplate.contains("#page=1&pagemode=thumbs"));
+        assertTrue(pdfTemplate.contains("<#if \"true\" == pdfSidebarOpen>"));
+        assertTrue(pdfTemplate.contains("viewerUrl += \"&pagemode=thumbs\";"));
+        assertTrue(pdfTemplate.contains("viewerUrl += \"&pagemode=none\";"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Follow-up fix for PR #755 after Copilot review.
- Update `PdfViewerCompatibilityTests#shouldRenderPdfSidebarModeByDefaultBasedOnConfig`:
  - remove fixed substring assertion for `#page=1&pagemode=thumbs`
  - assert template contains conditional `pdfSidebarOpen` branch and both `pagemode=thumbs` / `pagemode=none` values.
- Clarify `pdf.sidebar.open` config comment in `application.properties` to match boolean behavior (open/close only).

## Validation
- `mvn -q -pl server -Dtest=PdfViewerCompatibilityTests test`
