### PR TITLE
fix: correct HEIC/HEIF/AVIF preview URL for local/FTP files

### DIFF
--- a/server/src/main/java/cn/keking/service/impl/PictureFilePreviewImpl.java
+++ b/server/src/main/java/cn/keking/service/impl/PictureFilePreviewImpl.java
@@ -39,13 +39,15 @@ public class PictureFilePreviewImpl extends CommonPreviewImpl {
             // 不是http开头，浏览器不能直接访问，需下载到本地
             super.filePreviewHandle(url, model, fileAttribute);
             if ( url.toLowerCase().startsWith("file") || url.toLowerCase().startsWith("ftp")) {
-                model.addAttribute("imgUrls", fileAttribute.getName());
+                // 使用下载后的相对路径，以便模板正确构造图片访问URL
+                String currentUrl = (String) model.getAttribute("currentUrl");
+                model.addAttribute("imgUrls", currentUrl != null ? currentUrl : fileAttribute.getName());
             }else {
                 model.addAttribute("imgUrls", url);
             }
 
         }
-        if(suffix.equalsIgnoreCase("heic")||suffix.equalsIgnoreCase("heif")){
+        if(suffix.equalsIgnoreCase("heic")||suffix.equalsIgnoreCase("heif")||suffix.equalsIgnoreCase("avif")){
             return HEIC_FILE_PREVIEW_PAGE;
         }else {
             return PICTURE_FILE_PREVIEW_PAGE;


### PR DESCRIPTION
## Summary

Fixes two issues in HEIC/HEIF/AVIF file preview implementation:

### Bug Fix: Wrong URL for local/FTP files

When previewing HEIC/HEIF/AVIF files from `file://` or `ftp://` URLs, `PictureFilePreviewImpl` was setting `imgUrls` to `fileAttribute.getName()` (just the filename). However, `super.filePreviewHandle()` downloads the file and stores the actual relative path in `model.currentUrl`. The `heic.ftl` template uses `imgUrls` to construct image URLs, so a bare filename would produce incorrect URLs like `${baseUrl}photo.heic` instead of the correct downloaded file path.

**Fix:** Use `model.getAttribute("currentUrl")` — the actual downloaded file path — with a fallback to `fileAttribute.getName()` if `currentUrl` is null.

### Enhancement: Add AVIF suffix routing

The `wasm_heif.js` decoder in `static/heic/src/worker.js` already supports AVIF decoding (it detects AVIF by checking `array[8] == 0x61`). `FileType.java` also already lists `avif` in `PICTURE_TYPES`. However, the suffix check in `PictureFilePreviewImpl` didn't route AVIF to the HEIC template, causing AVIF files to use the generic picture template without client-side conversion support.

**Fix:** Add `suffix.equalsIgnoreCase("avif")` to the HEIC template routing condition.

## Testing

- HEIC/HEIF/AVIF files from HTTP URLs: unchanged, client-side WASM decoding via error handler
- HEIC/HEIF/AVIF files from file:///FTP URLs: now correctly uses downloaded file path
- AVIF files: now properly routed to heic.ftl template with WASM decoder

Closes #664