### PR TITLE
Optimize LuckyExcel xlsx preview conversion with Web Worker

### DIFF
--- a/server/src/main/resources/static/xlsx/luckyexcel-worker.js
+++ b/server/src/main/resources/static/xlsx/luckyexcel-worker.js
@@ -1,0 +1,49 @@
+importScripts('./luckyexcel.umd.js');
+
+self.console.log = function () {};
+
+self.onmessage = function (event) {
+    var data = event.data || {};
+    var url = data.url;
+    var name = data.name;
+
+    if (!url) {
+        self.postMessage({
+            type: 'error',
+            message: '文件URL为空'
+        });
+        return;
+    }
+
+    try {
+        LuckyExcel.transformExcelToLuckyByUrl(
+            url,
+            name,
+            function (exportJson, luckysheetfile) {
+                if (!exportJson || !exportJson.sheets || exportJson.sheets.length === 0) {
+                    self.postMessage({
+                        type: 'error',
+                        message: '读取excel文件内容失败!'
+                    });
+                    return;
+                }
+
+                self.postMessage({
+                    type: 'success',
+                    exportJson: exportJson
+                });
+            },
+            function (error) {
+                self.postMessage({
+                    type: 'error',
+                    message: error && error.message ? error.message : String(error)
+                });
+            }
+        );
+    } catch (error) {
+        self.postMessage({
+            type: 'error',
+            message: error && error.message ? error.message : String(error)
+        });
+    }
+};

--- a/server/src/main/resources/static/xlsx/luckyexcel-worker.js
+++ b/server/src/main/resources/static/xlsx/luckyexcel-worker.js
@@ -1,3 +1,8 @@
+// LuckyExcel's bundled getBinaryContent reads window.XMLHttpRequest.
+// Web Worker exposes XMLHttpRequest on self, so provide a minimal window alias
+// before loading the UMD bundle.
+self.window = self;
+
 importScripts('./luckyexcel.umd.js');
 
 self.console.log = function () {};

--- a/server/src/main/resources/static/xlsx/luckyexcel.umd.js
+++ b/server/src/main/resources/static/xlsx/luckyexcel.umd.js
@@ -3938,7 +3938,7 @@ var LuckySheet = /** @class */function (_super) {
     _this.sheetList = allFileOption.sheetList;
     _this.imageList = allFileOption.imageList;
     _this.hide = allFileOption.hide;
-    console.log(allFileOption, 'allFileOption');
+    // console.log(allFileOption, 'allFileOption');
     _this.dataVerificationSelectCount = allFileOption.dataVerificationSelectCount;
     //Output
     _this.name = sheetName;

--- a/server/src/main/resources/web/officeweb.ftl
+++ b/server/src/main/resources/web/officeweb.ftl
@@ -205,37 +205,40 @@
     // 异步加载Excel文件
     async function loadTextAsync() {
         if (isLoading) return;
-        
+
         isLoading = true;
         updateProgress(10);
-        
+
         try {
             initWaterMark();
-            
+
             const value = url;
             const name = '${file.name}';
-            
+
             if (!value) {
                 showError('文件URL为空');
                 return;
             }
 
             updateProgress(30);
-            
+
             // 使用异步方式加载
             await new Promise(resolve => setTimeout(resolve, 100)); // 给UI更新一点时间
-            
-            // 或者使用现有的同步方法，但放在setTimeout中避免阻塞
-            await transformWithTimeout(value, name);
-            
+
+            const exportJson = await transformWithWorker(value, name);
+
+            updateProgress(80);
+
+            await createLuckysheet(exportJson);
+
             updateProgress(100);
-            
+
             // 延迟隐藏加载界面，让用户看到加载完成
             setTimeout(() => {
                 hideLoading();
                 isLoading = false;
             }, 500);
-            
+
         } catch (error) {
             console.error('加载Excel失败:', error);
             showError('加载失败: ' + error.message);
@@ -243,35 +246,87 @@
         }
     }
 
-    // 使用setTimeout将同步任务拆分
-    function transformWithTimeout(value, name) {
+    function transformWithWorker(value, name) {
         return new Promise((resolve, reject) => {
             updateProgress(50);
-            
-            // 将转换过程放在setTimeout中，避免阻塞主线程
-            setTimeout(() => {
+
+            if (!window.Worker) {
+                transformOnMainThread(value, name, resolve, reject);
+                return;
+            }
+
+            let worker;
+            try {
+                worker = new Worker('xlsx/luckyexcel-worker.js');
+            } catch (error) {
+                transformOnMainThread(value, name, resolve, reject);
+                return;
+            }
+
+            let settled = false;
+
+            worker.onmessage = function(event) {
+                const data = event.data || {};
+
+                if (data.type === 'success') {
+                    settled = true;
+                    worker.terminate();
+                    resolve(data.exportJson);
+                    return;
+                }
+
+                if (data.type === 'error') {
+                    settled = true;
+                    worker.terminate();
+                    reject(new Error(data.message || 'Excel转换失败'));
+                }
+            };
+
+            worker.onerror = function(error) {
+                worker.terminate();
+                if (!settled) {
+                    transformOnMainThread(value, name, resolve, reject);
+                }
+            };
+
+            worker.postMessage({
+                url: value,
+                name: name
+            });
+        });
+    }
+
+    function transformOnMainThread(value, name, resolve, reject) {
+        try {
+            LuckyExcel.transformExcelToLuckyByUrl(value, name, function(exportJson, luckysheetfile) {
+                if (!exportJson || !exportJson.sheets || exportJson.sheets.length === 0) {
+                    reject(new Error("读取excel文件内容失败!"));
+                    return;
+                }
+
+                resolve(exportJson);
+            }, function(error) {
+                reject(error);
+            });
+        } catch (error) {
+            reject(error);
+        }
+    }
+
+    function createLuckysheet(exportJson) {
+        return new Promise((resolve, reject) => {
+            requestAnimationFrame(() => {
                 try {
-                    LuckyExcel.transformExcelToLuckyByUrl(value, name, function(exportJson, luckysheetfile){
-                        if(exportJson.sheets==null || exportJson.sheets.length==0){
-                            reject(new Error("读取excel文件内容失败!"));
-                            return;
-                        }
-                        
-                        updateProgress(80);
-                        
-                        // 使用requestAnimationFrame来更新UI，避免阻塞
-                        requestAnimationFrame(() => {
-                            try {
-                                window.luckysheet.destroy();
-                                window.luckysheet.create({
-                                    container: 'luckysheet',
-                                    lang: "zh",
-                                    showtoolbarConfig:{
-                                        image: true,
-                                        print: true,
-                                        exportXlsx: true,
-                                    },
-                                   allowCopy: true, // 是否允许拷贝
+                    window.luckysheet.destroy();
+                    window.luckysheet.create({
+                        container: 'luckysheet',
+                        lang: "zh",
+                        showtoolbarConfig:{
+                            image: true,
+                            print: true,
+                            exportXlsx: true,
+                        },
+                        allowCopy: true, // 是否允许拷贝
                 showtoolbar:  ${xlsxshowtoolbar?string('true','false')},  // 是否显示工具栏
                 showinfobar: true, // 是否显示顶部信息栏
                 // myFolderUrl: "/",//作用：左上角<返回按钮的链接
@@ -287,29 +342,23 @@
                 sheetFormulaBar: false, // 是否显示公式栏
                 enableAddBackTop: true,//返回头部按钮
                 forceCalculation: false, //下面是导出插件 默认关闭
-                                    data: exportJson.sheets,
-                                    title: exportJson.info.name,
-                                    userInfo: exportJson.info.name.creator,
-                                    // 添加加载完成的回调
-                                    hook: {
-                                        workbookCreateAfter: function() {
-                                            resolve();
-                                        }
-                                    }
-                                });
-                                
-                                updateProgress(90);
-                                
-                            } catch (err) {
-                                reject(err);
+                        data: exportJson.sheets,
+                        title: exportJson.info.name,
+                        userInfo: exportJson.info.name.creator,
+                        // 添加加载完成的回调
+                        hook: {
+                            workbookCreateAfter: function() {
+                                resolve();
                             }
-                        });
+                        }
                     });
-                    
-                } catch (error) {
-                    reject(error);
+
+                    updateProgress(90);
+
+                } catch (err) {
+                    reject(err);
                 }
-            }, 100);
+            });
         });
     }
 

--- a/server/src/main/resources/web/officeweb.ftl
+++ b/server/src/main/resources/web/officeweb.ftl
@@ -264,6 +264,17 @@
             }
 
             let settled = false;
+            const fallbackToMainThread = function(error) {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                worker.terminate();
+                if (error) {
+                    console.warn('Excel Worker转换失败，回退主线程转换:', error);
+                }
+                transformOnMainThread(value, name, resolve, reject);
+            };
 
             worker.onmessage = function(event) {
                 const data = event.data || {};
@@ -276,17 +287,12 @@
                 }
 
                 if (data.type === 'error') {
-                    settled = true;
-                    worker.terminate();
-                    reject(new Error(data.message || 'Excel转换失败'));
+                    fallbackToMainThread(data.message || 'Excel转换失败');
                 }
             };
 
             worker.onerror = function(error) {
-                worker.terminate();
-                if (!settled) {
-                    transformOnMainThread(value, name, resolve, reject);
-                }
+                fallbackToMainThread(error && error.message ? error.message : error);
             };
 
             worker.postMessage({


### PR DESCRIPTION
### Problem

When previewing large xlsx files, LuckyExcel performs Excel parsing and conversion on the main thread. For files with many shared strings, styles, or sheets, Chrome can report warnings such as:

`[Violation] 'setTimeout' handler took xxxxms`

The existing code wraps `LuckyExcel.transformExcelToLuckyByUrl` in `setTimeout`, but this only delays execution. The conversion still runs synchronously on the main thread and can block page interaction and loading UI updates.

There is also a debug log in `luckyexcel.umd.js`:

`console.log(allFileOption, 'allFileOption')`

For large files, `allFileOption` may contain huge structures such as `sharedStrings`, which makes DevTools logging slower and increases perceived loading cost.

### Solution

This change moves LuckyExcel xlsx conversion into a Web Worker:

- Add `xlsx/luckyexcel-worker.js`
- Load `luckyexcel.umd.js` inside the worker with `importScripts`
- Run `LuckyExcel.transformExcelToLuckyByUrl` in the worker
- Send converted `exportJson` back to the main thread
- Keep `luckysheet.create` on the main thread, since DOM rendering must remain there
- Add fallback to the original main-thread conversion if Worker is unavailable or blocked
- Comment out the large `allFileOption` debug log

### Notes

This reduces main-thread blocking during Excel parsing/conversion. Very large files may still spend time in `luckysheet.create`, because rendering must happen on the main thread.

### Verification

- `git diff --check`
- `node --check server/src/main/resources/static/xlsx/luckyexcel-worker.js`
- `mvn -s <temporary-aspose-settings> -U clean package -Dmaven.test.skip=true` with JDK 21 generated `server/target/kkFileView-5.0.0.tar.gz`
