### PR TITLE
fix: protect addTask with trust filters

### DIFF
--- a/server/src/main/java/cn/keking/config/WebConfig.java
+++ b/server/src/main/java/cn/keking/config/WebConfig.java
@@ -46,6 +46,7 @@ public class WebConfig implements WebMvcConfigurer {
         filterUri.add("/onlinePreview");
         filterUri.add("/picturesPreview");
         filterUri.add("/getCorsFile");
+        filterUri.add("/addTask");
         TrustHostFilter filter = new TrustHostFilter();
         FilterRegistrationBean<TrustHostFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(filter);
@@ -59,6 +60,7 @@ public class WebConfig implements WebMvcConfigurer {
         filterUri.add("/onlinePreview");
         filterUri.add("/picturesPreview");
         filterUri.add("/getCorsFile");
+        filterUri.add("/addTask");
         TrustDirFilter filter = new TrustDirFilter();
         FilterRegistrationBean<TrustDirFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(filter);

--- a/server/src/test/java/cn/keking/config/WebConfigTests.java
+++ b/server/src/test/java/cn/keking/config/WebConfigTests.java
@@ -1,0 +1,27 @@
+package cn.keking.config;
+
+import cn.keking.web.filter.TrustDirFilter;
+import cn.keking.web.filter.TrustHostFilter;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WebConfigTests {
+
+    private final WebConfig webConfig = new WebConfig();
+
+    @Test
+    void shouldApplyTrustHostFilterToAddTaskEndpoint() {
+        FilterRegistrationBean<TrustHostFilter> registration = webConfig.getTrustHostFilter();
+
+        assertTrue(registration.getUrlPatterns().contains("/addTask"));
+    }
+
+    @Test
+    void shouldApplyTrustDirFilterToAddTaskEndpoint() {
+        FilterRegistrationBean<TrustDirFilter> registration = webConfig.getTrustDirFilter();
+
+        assertTrue(registration.getUrlPatterns().contains("/addTask"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `/addTask` to `TrustHostFilter` coverage so queued conversion requests respect trusted host / blocked host rules.
- Add `/addTask` to `TrustDirFilter` coverage so `file://` queue requests keep the same local directory restrictions as preview endpoints.
- Add regression tests for the filter registration coverage.

Closes #765

## Validation
- `mvn -q -pl server -Dtest=WebConfigTests,TrustHostFilterTests test`
- `mvn -q -pl server -DskipTests compile`

## Note
- `mvn -q -pl server test` currently fails in existing `EncodingTests#testCharDet` because `ClassLoader.getResource("testData")` returns null in this environment. The failure is unrelated to this change.
