### PR TITLE
Add Windows and macOS to CI build matrix and fix cross-platform issues

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,7 @@ jobs:
       run: mvn -B package "-Dmaven.test.skip=true" --file pom.xml
 
     - name: Upload Linux distribution package
-      if: success()
+      if: success() && runner.os == 'Linux'
       uses: actions/upload-artifact@v4
       with:
         name: kkfileview-linux
@@ -44,7 +44,7 @@ jobs:
         retention-days: 7
 
     - name: Upload Windows distribution package
-      if: success()
+      if: success() && runner.os == 'Windows'
       uses: actions/upload-artifact@v4
       with:
         name: kkfileview-windows

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout repository
@@ -33,7 +33,7 @@ jobs:
           ${{ runner.os }}-maven-
 
     - name: Build with Maven
-      run: mvn -B package -Dmaven.test.skip=true --file pom.xml
+      run: mvn -B package "-Dmaven.test.skip=true" --file pom.xml
 
     - name: Upload Linux distribution package
       if: success()
@@ -50,3 +50,6 @@ jobs:
         name: kkfileview-windows
         path: server/target/*.zip
         retention-days: 7
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   e2e-nightly:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 50
 
     steps:
@@ -116,6 +116,3 @@ jobs:
           path: |
             /tmp/kkfileview.log
             /tmp/fixture-server.log
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   e2e-nightly:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 50
 
     steps:
@@ -116,3 +116,6 @@ jobs:
           path: |
             /tmp/kkfileview.log
             /tmp/fixture-server.log
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]


### PR DESCRIPTION
## What is the purpose of this PR

Expand the **Maven** (`.github/workflows/maven.yml`) and **Nightly E2E** (`.github/workflows/nightly-e2e.yml`) GitHub Actions workflows to run on Windows and macOS in addition to Ubuntu. 

The project documentation includes platform-specific installation and runtime guidance for Windows, macOS, and Linux. However, both workflows currently execute only on Ubuntu, leaving Windows- and macOS-specific build and runtime issues untested in CI.

These workflows were selected because they cover the project's primary build and end-to-end testing. Running them across all supported operating systems helps detect platform-specific regressions earlier, improves confidence in cross-platform compatibility, and ensures that the CI pipeline reflects the environments documented and supported by the project.

## Expected results

The **Maven** and **Nightly E2E**  workflows complete successfully on Ubuntu, Windows, and macOS.

## Actual results

The **Nightly E2E** workflow runs successfully on Ubuntu, Windows, and macOS after expanding the OS matrix.

For the **Maven** workflow (`.github/workflows/maven.yml`), Ubuntu and macOS complete successfully after the OS expansion, but Windows fails during the Maven build step.

The command

`mvn -B package -Dmaven.test.skip=true --file pom.xml`

is parsed incorrectly on Windows, causing Maven to treat `.test.skip=true` as a lifecycle phase and fail with:

`Unknown lifecycle phase ".test.skip=true"`

## Description of fix

- Expanded both the **Maven** and **Nightly E2E** workflows to run on `ubuntu-latest`, `windows-latest`, and `macos-latest`.
- Quoted the Maven property argument (`"-Dmaven.test.skip=true"`) so Windows parses it correctly.