### PR TITLE
[codex] Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are handled for the latest released version of kkFileView and the
+current `master` branch. Older versions may be evaluated case by case, but users
+are encouraged to upgrade to the latest release before reporting or verifying a
+security issue.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately through GitHub Private
+Vulnerability Reporting:
+
+https://github.com/kekingcn/kkFileView/security/advisories/new
+
+Do not publish vulnerability details, proof-of-concept code, exploit steps,
+sensitive logs, or private deployment information in public GitHub issues,
+discussions, pull requests, or comments.
+
+When reporting a vulnerability, please include as much of the following
+information as you can safely share:
+
+- Affected kkFileView version or commit
+- Deployment mode, operating system, JDK version, and related middleware
+- Clear reproduction steps
+- Impact assessment and affected feature or endpoint
+- Sanitized logs, screenshots, or sample files if they are required to reproduce
+  the issue
+- Whether the issue is already being disclosed elsewhere
+
+The maintainers will review private reports, ask for additional information when
+needed, coordinate a fix, and publish disclosure information when appropriate.
+
+If the private reporting link is unavailable, please open a public issue only to
+request a private contact channel, without including technical vulnerability
+details.
+
+---
+
+# 安全策略
+
+## 支持版本
+
+kkFileView 安全修复主要覆盖最新发布版本和当前 `master` 分支。旧版本问题会视影响范围和维护成本单独评估，但建议用户优先升级到最新版本后再验证或报告安全问题。
+
+## 报告安全漏洞
+
+请通过 GitHub Private Vulnerability Reporting 私密提交安全漏洞：
+
+https://github.com/kekingcn/kkFileView/security/advisories/new
+
+请不要在公开 GitHub issue、discussion、pull request 或评论中发布漏洞细节、PoC、利用步骤、敏感日志或私有部署信息。
+
+提交漏洞时，请在可安全分享的前提下尽量提供以下信息：
+
+- 受影响的 kkFileView 版本或提交
+- 部署方式、操作系统、JDK 版本和相关中间件信息
+- 清晰的复现步骤
+- 影响范围，以及受影响的功能或接口
+- 复现所需的脱敏日志、截图或样例文件
+- 该问题是否已在其他渠道披露
+
+维护者会在私密渠道中评估报告，在需要时继续确认细节，协调修复，并在适当时发布披露信息。
+
+如果私密报告链接不可用，请只在公开 issue 中请求私密联系方式，不要包含任何技术漏洞细节。


### PR DESCRIPTION
## Summary

- Add a repository-level `SECURITY.md` file.
- Document the private vulnerability reporting channel for kkFileView.
- Provide bilingual guidance for supported versions, responsible disclosure, and what information to include in a private report.

## Why

GitHub renders `/security/policy` from `SECURITY.md`. The repository already has Private Vulnerability Reporting enabled, so this file gives reporters a visible policy page and reinforces that vulnerability details should not be posted publicly.

Related to #769.

## Validation

- Ran `git diff --check`.
- Ran `git diff --cached --check` before committing.
- Documentation-only change; no runtime tests required.