### PR TITLE
fix: refresh ImageIO plugins before PDF conversion

### DIFF
--- a/server/src/main/java/cn/keking/service/PdfToJpgService.java
+++ b/server/src/main/java/cn/keking/service/PdfToJpgService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 
+import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -93,6 +94,8 @@ public class PdfToJpgService {
 
     @PostConstruct
     public void init() {
+        refreshImageIoPlugins();
+
         int maxThreads = ConfigConstants.getPdfMaxThreads();
         // 使用固定大小的虚拟线程池
         this.virtualThreadExecutor = Executors.newFixedThreadPool(maxThreads,
@@ -102,6 +105,13 @@ public class PdfToJpgService {
 
         // 启动缓存清理任务
         scheduleCacheCleanup();
+    }
+
+    static void refreshImageIoPlugins() {
+        // ImageIO only scans once automatically. If another launcher or Java agent initializes
+        // it before Spring Boot installs its application class loader, nested JAR providers such
+        // as jbig2-imageio remain invisible until the application class path is scanned again.
+        ImageIO.scanForPlugins();
     }
 
     @PreDestroy

--- a/server/src/test/java/cn/keking/service/PdfToJpgServiceTests.java
+++ b/server/src/test/java/cn/keking/service/PdfToJpgServiceTests.java
@@ -1,0 +1,51 @@
+package cn.keking.service;
+
+import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
+import javax.imageio.spi.IIORegistry;
+import javax.imageio.spi.ImageReaderSpi;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PdfToJpgServiceTests {
+
+    @Test
+    void shouldRediscoverJbig2ReaderAfterInitialRegistryMiss() {
+        IIORegistry registry = IIORegistry.getDefaultInstance();
+        List<ImageReaderSpi> providers = findJbig2Providers(registry);
+        assertFalse(providers.isEmpty(), "jbig2-imageio must be present on the test class path");
+
+        try {
+            providers.forEach(registry::deregisterServiceProvider);
+            assertFalse(hasJbig2Reader());
+
+            PdfToJpgService.refreshImageIoPlugins();
+
+            assertTrue(hasJbig2Reader());
+        } finally {
+            providers.forEach(registry::registerServiceProvider);
+        }
+    }
+
+    private static List<ImageReaderSpi> findJbig2Providers(IIORegistry registry) {
+        Iterator<ImageReaderSpi> providers = registry.getServiceProviders(
+                ImageReaderSpi.class,
+                provider -> Arrays.stream(((ImageReaderSpi) provider).getFormatNames())
+                        .anyMatch("JBIG2"::equalsIgnoreCase),
+                true
+        );
+        List<ImageReaderSpi> result = new ArrayList<>();
+        providers.forEachRemaining(result::add);
+        return result;
+    }
+
+    private static boolean hasJbig2Reader() {
+        return ImageIO.getImageReadersByFormatName("JBIG2").hasNext();
+    }
+}


### PR DESCRIPTION
## Summary

- rescan ImageIO plugins under the Spring Boot application class loader before PDF conversion starts
- add regression coverage for restoring the JBIG2 reader after an initial registry miss

## Root cause

Java ImageIO automatically scans providers only on its first API invocation. If a launcher, debugger, or Java agent initializes ImageIO before Spring Boot installs `LaunchedClassLoader`, providers inside nested JARs—including `jbig2-imageio`—remain absent from `IIORegistry` even though the dependency is packaged. PDFBox then reports `MissingImageReaderException` and omits JBIG2 images.

## Impact

PDF-to-image conversion can now render JBIG2 content correctly in environments where ImageIO was initialized before the application class loader became active.

## Validation

- `mvn -q -pl server -Dtest=PdfToJpgServiceTests test`
- `mvn -q -pl server '-Dtest=PdfToJpgServiceTests,PdfViewerCompatibilityTests,ServerMainTests,WebConfigTests,WebUtilsTests,FileControllerPathSecurityTests,TrustHostFilterTests' test`
- `mvn -q -pl server -DskipTests -Dassembly.skipAssembly=true package`
- packaged-JAR bootstrap probe reproduced the failure before the refresh (`jbig2=false`, 0 non-white pixels) and rendered successfully after the refresh (`jbig2=true`, 72,953 non-white pixels)

Full-suite note: `mvn -q -pl server test` still encounters the existing macOS path issue in `EncodingTests.testCharDet` (`testData\\0` is not found); it is unrelated to this change.

Fixes #778